### PR TITLE
fix(dovi): no longer a required dep (WIP)

### DIFF
--- a/Docs/PSY-Development.md
+++ b/Docs/PSY-Development.md
@@ -1,0 +1,3 @@
+[Top level](../README.md)
+
+# SVT-AV1-PSY

--- a/Source/App/EncApp/CMakeLists.txt
+++ b/Source/App/EncApp/CMakeLists.txt
@@ -47,9 +47,10 @@ set(all_files
     EbTime.h
     )
 
-if(LIBDOVI_FOUND)
+if(PC_LIBDOVI_FOUND)
   set(LIBDOVI_INCLUDE_DIRS ${LIBDOVI_INCLUDE_DIR})
   set(LIBDOVI_LIBRARIES ${LIBDOVI_LIBRARY})
+  add_compile_definitions(SvtAv1EncApp PRIVATE USE_LIBDOVI)
 endif()
 
 # App Source Files

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -14,7 +14,10 @@
 
 #include <stdio.h>
 #include <stdbool.h>
+
+#ifdef USE_LIBDOVI
 #include <libdovi/rpu_parser.h>
+#endif
 
 #include "EbSvtAv1Enc.h"
 
@@ -188,7 +191,9 @@ typedef struct EbConfig {
     // Instance Index
     uint8_t instance_idx;
 
+#ifdef USE_LIBDOVI
     const DoviRpuOpaqueList *dovi_rpus;
+#endif
 
     char *fgs_table_path;
 } EbConfig;

--- a/Source/App/EncApp/EbAppProcessCmd.c
+++ b/Source/App/EncApp/EbAppProcessCmd.c
@@ -18,7 +18,11 @@
 #include <string.h>
 #include <math.h>
 #include <ctype.h>
+
+#ifdef USE_LIBDOVI
 #include "EbSvtAv1Metadata.h"
+#endif
+
 #include "EbAppContext.h"
 #include "EbAppConfig.h"
 #include "EbSvtAv1ErrorCodes.h"
@@ -459,6 +463,7 @@ static EbErrorType retrieve_roi_map_event(SvtAv1RoiMap *roi_map, uint64_t pic_nu
     return EB_ErrorNone;
 }
 
+#ifdef USE_LIBDOVI
 static EbErrorType retrieve_dovi_rpu_for_frame(const DoviRpuOpaqueList *rpus, uint64_t pic_num, EbBufferHeaderType *header_ptr) {
     if (rpus == NULL) {
         return EB_ErrorNone;
@@ -478,6 +483,7 @@ static EbErrorType retrieve_dovi_rpu_for_frame(const DoviRpuOpaqueList *rpus, ui
     dovi_data_free(rpu_payload);
     return EB_ErrorNone;
 }
+#endif
 
 static void free_private_data_list(void *node_head) {
     while (node_head) {
@@ -550,8 +556,9 @@ void process_input_buffer(EncChannel *channel) {
             //  test_update_qp_info(header_ptr->pts, header_ptr);
 #endif
             retrieve_roi_map_event(app_cfg->roi_map, header_ptr->pts, header_ptr);
+#ifdef USE_LIBDOVI
             retrieve_dovi_rpu_for_frame(app_cfg->dovi_rpus, header_ptr->pts, header_ptr);
-
+#endif
             // Send the picture
             if (svt_av1_enc_send_picture(component_handle, header_ptr) != EB_ErrorNone)
                 return_value = APP_ExitConditionFinished;


### PR DESCRIPTION
attempt to eliminate libdovi as a required dependency for SvtAv1EncApp to build (WIP, currently not working)