### PR TITLE
Add SVT-AV1-PSY branding to encoder print output

### DIFF
--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -5647,7 +5647,7 @@ EB_API const char *svt_av1_get_version(void) {
 
 EB_API void svt_av1_print_version(void) {
     SVT_INFO("-------------------------------------------\n");
-    SVT_INFO("SVT [version]:\tSVT-AV1 Encoder Lib %s\n", SVT_AV1_CVS_VERSION);
+    SVT_INFO("SVT [version]:\tSVT-AV1-PSY Encoder Lib %s\n", SVT_AV1_CVS_VERSION);
     const char *compiler =
 #if defined( _MSC_VER ) && (_MSC_VER >= 1930)
     "Visual Studio 2022"


### PR DESCRIPTION
Every time the encoder is initiated, it will print out the version and other information, I just simply added the psy branding. So instead of looking like this:
```
Svt[info]: -------------------------------------------
Svt[info]: SVT [version]:       SVT-AV1 Encoder Lib 55cdd260
Svt[info]: SVT [build]  :       Clang 16.0.6     64 bit
Svt[info]: LIB Build date: Feb  4 2024 03:05:42
Svt[info]: -------------------------------------------
```

it would look like this:
```
Svt[info]: -------------------------------------------
Svt[info]: SVT [version]:       SVT-AV1-PSY Encoder Lib 55cdd260
Svt[info]: SVT [build]  :       Clang 16.0.6     64 bit
Svt[info]: LIB Build date: Feb  4 2024 03:05:42
Svt[info]: -------------------------------------------
```