### PR TITLE
fix: Add enable libdovi flag windows build.bat

### DIFF
--- a/Build/windows/build.bat
+++ b/Build/windows/build.bat
@@ -158,6 +158,9 @@ if -%1-==-- (
 ) else if /I "%1"=="avx512" (
     set "cmake_eflags=%cmake_eflags% -DENABLE_AVX512=ON"
     shift
+) else if /I "%1"=="enable-libdovi" (
+    set "cmake_eflags=%cmake_eflags% -DLIBDOVI_FOUND=1"
+    shift
 ) else if /I "%1"=="lto" (
     set "cmake_eflags=%cmake_eflags% -DSVT_AV1_LTO=ON"
     shift
@@ -179,6 +182,6 @@ goto :args
 
 :help
     echo Batch file to build SVT-AV1 on Windows
-    echo Usage: build.bat [2022^|2019^|2017^|2015^|clean] [release^|debug] [nobuild] [test] [shared^|static] [c-only] [avx512] [no-apps] [no-dec] [no-enc]
+    echo Usage: build.bat [2022^|2019^|2017^|2015^|clean] [release^|debug] [nobuild] [test] [shared^|static] [c-only] [avx512] [enable-libdovi] [no-apps] [no-dec] [no-enc]
     exit /b 1
 goto :EOF


### PR DESCRIPTION
build parameter
```
build.bat mingw release static enable-libdovi
```
output
```
Svt[info]: -------------------------------------------
Svt[info]: SVT [version]:	SVT-AV1-PSY Encoder Lib 9f81da26-dirty
Svt[info]: SVT [build]  :	Clang 17.0.6	 64 bit
Svt[info]: LIB Build date: Feb 20 2024 04:44:53
Svt[info]: -------------------------------------------
Svt[warn]: Instance 1: The Subjective SSIM configuration is considered experimental at this stage. Keep in mind for benchmarking analysis that this configuration will likely harm metric performance.
Svt[info]: Number of logical cores available: 12
Svt[info]: Number of PPCS 71
Svt[info]: [asm level on system : up to avx2]
Svt[info]: [asm level selected : up to avx2]
Svt[info]: -------------------------------------------
Svt[info]: SVT [config]: main profile	tier (auto)	level (auto)
Svt[info]: SVT [config]: width / height / fps numerator / fps denominator 		: 1920 / 816 / 25 / 1
Svt[info]: Parsing Dolby Vision RPU file...
Svt[info]: SVT [config]: bit-depth / color format 					: 10 / YUV420
Svt[info]: SVT [config]: preset / tune / pred struct 					: 9 / Subjective SSIM / random access
Svt[info]: SVT [config]: gop size / mini-gop size / key-frame type 			: 251 / 16 / key frame
Svt[info]: Loaded 65554 DoVi RPUs
Svt[info]: SVT [config]: BRC mode / rate factor 					: CRF / 24 
Svt[info]: SVT [config]: AQ mode / variance boost strength / sample size / octile	: 2 / 2 / 8x8 / 6
Svt[info]: SVT [config]: Sharpness / level 						: 1 / 2
Svt[info]: -------------------------------------------
Encoding
```