### PR TITLE
Add new unutilized interpolation filter search levels to slower presets and better CLI docs

### DIFF
--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -1235,7 +1235,7 @@ ConfigEntry config_entry_psy[] = {
     // QP scale compress
     {SINGLE_INPUT,
      QP_SCALE_COMPRESS_STRENGTH_TOKEN,
-     "[PSY] QP scale compress strength, default is 1 [0-3]",
+     "[PSY] QP scale compress strength, default is 1 while SVT-AV1 default is 0 [0-3]",
      set_cfg_generic_token},
     // Termination
     {SINGLE_INPUT, NULL, NULL, NULL}};

--- a/Source/Lib/Encoder/Codec/EncModeConfig.c
+++ b/Source/Lib/Encoder/Codec/EncModeConfig.c
@@ -8411,6 +8411,10 @@ void svt_aom_sig_deriv_mode_decision_config(SequenceControlSet *scs, PictureCont
     pcs->interpolation_search_level = 0;
     if (enc_mode <= ENC_MRS)
         pcs->interpolation_search_level = 1;
+    else if (enc_mode <= ENC_M2)
+        pcs->interpolation_search_level = 2;
+    else if (enc_mode <= ENC_M4)
+        pcs->interpolation_search_level = 3;
     else if (enc_mode <= ENC_M8)
         pcs->interpolation_search_level = 4;
     else {


### PR DESCRIPTION
Title is the main subject.

This time, I added speed features which are currently not utilized by svt-av1 and I decided to make them available to svt-av1-psy. More testing is needed until it's merged into the main branch.

The main goal is to increase quality with better AV1 interpolation filter search choices like Regular, Sharp and Smooth.

Currently, pruning with this encoding feature is very crude.
It either fully enables it in the research presets or greatly prunes the search for any realistic encoding preset.

I've done some testing on my side and it gives a non-negligible boost to fidelity at higher bitrates and a small boost to quality at lower presets.

Be sure to test this patch before suggesting any preset changes.

I've also added some new docs to fix the CLI qp-scale-compress option description :)