### PR TITLE
Disabling SSIM-cost transform decisions, keeping SSIM-cost mode decisions

### DIFF
--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -9268,7 +9268,7 @@ static void md_encode_block(PictureControlSet *pcs, ModeDecisionContext *ctx, ui
     }
     // 3rd Full-Loop
     ctx->md_stage        = MD_STAGE_3;
-    ctx->tune_ssim_level = (pcs->scs->static_config.tune == 2 || pcs->ppcs->scs->static_config.tune == 3) && (ctx->pd_pass == PD_PASS_1) ? SSIM_LVL_3 : SSIM_LVL_0;
+    ctx->tune_ssim_level = (pcs->scs->static_config.tune == 2 || pcs->ppcs->scs->static_config.tune == 3) && (ctx->pd_pass == PD_PASS_1) ? SSIM_LVL_1 : SSIM_LVL_0;
     md_stage_3(pcs,
                ctx,
                input_pic,

--- a/Source/Lib/Encoder/Codec/EncModeConfig.c
+++ b/Source/Lib/Encoder/Codec/EncModeConfig.c
@@ -7772,7 +7772,7 @@ void svt_aom_sig_deriv_enc_dec(SequenceControlSet *scs, PictureControlSet *pcs, 
         skip_sub_depth_lvl = 2;
 
     set_skip_sub_depth_ctrls(&ctx->skip_sub_depth_ctrls, skip_sub_depth_lvl);
-    ctx->tune_ssim_level = scs->static_config.tune == 3 ? SSIM_LVL_3 : SSIM_LVL_0;
+    ctx->tune_ssim_level = scs->static_config.tune == 3 ? SSIM_LVL_1 : SSIM_LVL_0;
 }
 /*
 * return the 4x4 level


### PR DESCRIPTION
Title is the subject of this little patch, implemented in a much cleaner way than the previous patchset.

It works well and noticeably improves visual performance.

```Foodmarket_full_ssim.mkv 21.2MB

Mean: 71.68296504
Median: 71.74654513
Std Dev: 1.28901421
5th Percentile: 69.61743804
95th Percentile: 73.74350790

Foodmarket_ssim-lvl1_mode-only_notx+ssim-rd.mkv 20.9MB

Mean: 71.87496879
Median: 71.99473719
Std Dev: 1.16776454
5th Percentile: 70.05028997
95th Percentile: 73.80584387```

Patch explanation: It disables the SSIM-cost based tunings (which employ actual SSIM metric usage) and only keeps the SSIM-based RD from aomenc, resulting in improved visual performance.

This set of patches disables the SSIM mode decision and the SSIM transform (TX) decisions. Disabling TX decisions gives the biggest gain by far visually. Further optimizations will come by tuning the actual SSIM RD function before moving on to proper internal psy quantization.