### PR TITLE
EncApp: Add support for HDR10+ JSON file

### DIFF
--- a/Build/linux/build.sh
+++ b/Build/linux/build.sh
@@ -80,6 +80,8 @@ For each enable-*, there is a disable-* option, and vice versa.
     enable-lto
     --enable-libdovi,   Enable support for Dolby Vision RPUs (if libdovi is found)
     enable-libdovi
+    --enable-libhdr10plus-rs,   Enable support for HDR10+ metadata (if libhdr10plus-rs is found)
+    enable-libhdr10plus-rs
     --disable-native,   Disable the use of -march=native
     disable-native
     --enable-pgo,       Enable profile guided optimization
@@ -302,6 +304,7 @@ parse_options() {
                 esac
                 ;;
             libdovi) CMAKE_EXTRA_FLAGS="$CMAKE_EXTRA_FLAGS -DLIBDOVI_FOUND=1" ;;
+            libhdr10plus-rs) CMAKE_EXTRA_FLAGS="$CMAKE_EXTRA_FLAGS -DLIBHDR10PLUS_RS_FOUND=1" ;;
             *) print_message "Unknown option: $1" ;;
             esac
             shift

--- a/Source/App/EncApp/CMakeLists.txt
+++ b/Source/App/EncApp/CMakeLists.txt
@@ -40,6 +40,30 @@ else()
   execute_process(COMMAND ${CMAKE_COMMAND} -E echo_append "-- Building with libdovi support - No\n")
 endif()
 
+# libhdr10plus-rs detection & preprocessor macro
+option(LIBHDR10PLUS_RS_FOUND "Use the libhdr10plus-rs library" OFF)
+if(LIBHDR10PLUS_RS_FOUND)
+  if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_LIBHDR10PLUS_RS libhdr10plus-rs QUIET)
+  endif()
+
+  find_library(LIBHDR10PLUS_RS_LIBRARY NAMES hdr10plus-rs libhdr10plus-rs
+                               PATHS ${PC_LIBHDR10PLUS_RS_LIBDIR})
+  if(NOT LIBHDR10PLUS_RS_LIBRARY)
+  message(FATAL_ERROR "libhdr10plus-rs library not found!")
+  endif()
+
+  find_path(LIBHDR10PLUS_RS_INCLUDE_DIR NAMES libhdr10plus-rs/hdr10plus.h
+                                PATHS ${PC_LIBHDR10PLUS_RS_INCLUDEDIR})
+
+  set(LIBHDR10PLUS_RS_INCLUDE_DIRS ${LIBHDR10PLUS_RS_INCLUDE_DIR})
+  set(LIBHDR10PLUS_RS_LIBRARIES ${LIBHDR10PLUS_RS_LIBRARY})
+  add_definitions(-DLIBHDR10PLUS_RS_FOUND=1)
+  execute_process(COMMAND ${CMAKE_COMMAND} -E echo_append "-- Building with libhdr10plus-rs support - Yes\n")
+else()
+  execute_process(COMMAND ${CMAKE_COMMAND} -E echo_append "-- Building with libhdr10plus-rs support - No\n")
+endif()
+
 set(all_files
     ../../API/EbDebugMacros.h
     ../../API/EbSvtAv1.h
@@ -75,7 +99,8 @@ endif()
 # Link the Encoder App
 target_link_libraries(SvtAv1EncApp
         SvtAv1Enc
-        ${LIBDOVI_LIBRARY})
+        ${LIBDOVI_LIBRARY}
+        ${LIBHDR10PLUS_RS_LIBRARY})
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Android")
     target_link_libraries(SvtAv1EncApp ${PLATFORM_LIBS})
 elseif(UNIX)

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -17,6 +17,9 @@
 #ifdef LIBDOVI_FOUND
 #include <libdovi/rpu_parser.h>
 #endif
+#ifdef LIBHDR10PLUS_RS_FOUND
+#include <libhdr10plus-rs/hdr10plus.h>
+#endif
 
 #include "EbSvtAv1Enc.h"
 
@@ -190,6 +193,9 @@ typedef struct EbConfig {
     uint8_t instance_idx;
 #ifdef LIBDOVI_FOUND
     const DoviRpuOpaqueList *dovi_rpus;
+#endif
+#ifdef LIBHDR10PLUS_RS_FOUND
+    Hdr10PlusRsJsonOpaque *hdr10plus_json;
 #endif
 
     char *fgs_table_path;

--- a/Source/App/EncApp/EbAppProcessCmd.c
+++ b/Source/App/EncApp/EbAppProcessCmd.c
@@ -18,7 +18,7 @@
 #include <string.h>
 #include <math.h>
 #include <ctype.h>
-#ifdef LIBDOVI_FOUND
+#if defined(LIBDOVI_FOUND) || defined(LIBHDR10PLUS_RS_FOUND)
 #include "EbSvtAv1Metadata.h"
 #endif
 #include "EbAppContext.h"
@@ -479,6 +479,25 @@ static EbErrorType retrieve_dovi_rpu_for_frame(const DoviRpuOpaqueList *rpus, ui
     return EB_ErrorNone;
 }
 #endif
+#ifdef LIBHDR10PLUS_RS_FOUND
+static EbErrorType retrieve_hdr10plus_payload_for_frame(Hdr10PlusRsJsonOpaque *hdr10plus_json, uint64_t pic_num, EbBufferHeaderType *header_ptr) {
+    if (hdr10plus_json == NULL) {
+        return EB_ErrorNone;
+    }
+
+    const Hdr10PlusRsData *payload = hdr10plus_rs_write_av1_metadata_obu_t35_complete(hdr10plus_json, pic_num);
+    if (!payload) {
+        return EB_ErrorNone;
+    }
+
+    if (svt_add_metadata(header_ptr, EB_AV1_METADATA_TYPE_ITUT_T35, payload->data, payload->len)) {
+        hdr10plus_rs_data_free(payload);
+        return EB_ErrorInsufficientResources;
+    }
+    hdr10plus_rs_data_free(payload);
+    return EB_ErrorNone;
+}
+#endif
 
 static void free_private_data_list(void *node_head) {
     while (node_head) {
@@ -553,6 +572,9 @@ void process_input_buffer(EncChannel *channel) {
             retrieve_roi_map_event(app_cfg->roi_map, header_ptr->pts, header_ptr);
 #ifdef LIBDOVI_FOUND
             retrieve_dovi_rpu_for_frame(app_cfg->dovi_rpus, header_ptr->pts, header_ptr);
+#endif
+#ifdef LIBHDR10PLUS_RS_FOUND
+            retrieve_hdr10plus_payload_for_frame(app_cfg->hdr10plus_json, header_ptr->pts, header_ptr);
 #endif
             // Send the picture
             if (svt_av1_enc_send_picture(component_handle, header_ptr) != EB_ErrorNone)


### PR DESCRIPTION
Requires new C API lib from https://github.com/quietvoid/hdr10plus_tool/tree/main/hdr10plus
Lazy approach where the JSON is parsed and returned as a handle. And payload is generated for every frame.