### PR TITLE
Fixes cmake/pkgconfig library location for dovi/hdr10plus

### DIFF
--- a/Source/App/CMakeLists.txt
+++ b/Source/App/CMakeLists.txt
@@ -15,12 +15,13 @@ cmake_minimum_required(VERSION 3.5...3.28)
 
 # Include Subdirectories
 include_directories(${PROJECT_SOURCE_DIR}/Source/API/)
+find_package(PkgConfig REQUIRED)
 
 # libdovi detection & preprocessor macro
 option(LIBDOVI_FOUND "Use the libdovi library" OFF)
 if(LIBDOVI_FOUND)
   if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_LIBDOVI libdovi QUIET)
+  pkg_check_modules(PC_LIBDOVI dovi QUIET)
   endif()
 
   find_library(LIBDOVI_LIBRARY NAMES dovi libdovi
@@ -44,7 +45,7 @@ endif()
 option(LIBHDR10PLUS_RS_FOUND "Use the libhdr10plus-rs library" OFF)
 if(LIBHDR10PLUS_RS_FOUND)
   if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_LIBHDR10PLUS_RS libhdr10plus-rs QUIET)
+  pkg_check_modules(PC_LIBHDR10PLUS_RS hdr10plus-rs QUIET)
   endif()
 
   find_library(LIBHDR10PLUS_RS_LIBRARY NAMES hdr10plus-rs libhdr10plus-rs


### PR DESCRIPTION
When building with libdovi and/or libhdr10plus, the pkg-config library searching was not working. These changes make it functional.

re: the module name changes, the projects don't use the `lib` prefix for their pkg-config naming, as seen in this section of their Cargo.tomls.
https://github.com/quietvoid/dovi_tool/blob/46662ed9c477f6245b398d81af8a167de46a9cbe/dolby_vision/Cargo.toml#L38
https://github.com/quietvoid/hdr10plus_tool/blob/a26b08587615c7a1f6ef71970484aa0ea40b24a0/hdr10plus/Cargo.toml#L32