### PR TITLE
fix: swapped CRF and max bit rate in logs

### DIFF
--- a/Source/Lib/Globals/enc_settings.c
+++ b/Source/Lib/Globals/enc_settings.c
@@ -1174,8 +1174,8 @@ void svt_av1_print_lib_params(SequenceControlSet *scs) {
         case SVT_AV1_RC_MODE_CQP_OR_CRF:
             if (config->max_bit_rate)
                 SVT_INFO(
-                    "SVT [config]: BRC mode / %s / max bitrate (kbps)\t\t\t: %s / %d / "
-                    "%.2f\n",
+                    "SVT [config]: BRC mode / %s / max bitrate (kbps)\t\t\t: %s / %.2f / "
+                    "%d\n",
                     scs->tpl || scs->static_config.enable_variance_boost ? "rate factor" : "CQP Assignment",
                     scs->tpl || scs->static_config.enable_variance_boost ? "capped CRF" : "CQP",
                     get_extended_crf(config),


### PR DESCRIPTION
This commit fixes a regression that was introduced in 389681329d951d6f64a48259f9798c06899b346f, where the wrong format specifier was updated for extended CRF, leading to CRF and MBR values being swapped in logs.

---

Before:

```
$ SvtAv1EncApp -i blue_sky_1080p25.y4m --mbr 1100k -b output.ivf
[…]
Svt[info]: SVT [config]: BRC mode / rate factor / max bitrate (kbps)			: capped CRF / 1100 / 35.00
                                                                                                       ^^^^^^^^^^^^
                                                                                                          swapped
```

After:

```
$ SvtAv1EncApp -i blue_sky_1080p25.y4m --mbr 1100k -b output.ivf
[…]
Svt[info]: SVT [config]: BRC mode / rate factor / max bitrate (kbps)			: capped CRF / 35.00 / 1100
```