### PR TITLE
fix: better KF sharpness RD rshift logic

### DIFF
--- a/Source/Lib/Codec/deblocking_filter.c
+++ b/Source/Lib/Codec/deblocking_filter.c
@@ -1196,7 +1196,7 @@ EbErrorType svt_av1_pick_filter_level(EbPictureBufferDesc *srcBuffer, // source 
 
     int32_t sharpness_val = pcs->scs->static_config.sharpness;
     uint8_t tune = pcs->scs->static_config.tune;
-    if (frm_hdr->frame_type == KEY_FRAME && tune == 3) {
+    if (frm_hdr->frame_type == KEY_FRAME && tune == 3 && pcs->scs->static_config.sharpness <= 5) {
         lf->sharpness_level = sharpness_val + 2;
     } else {
         lf->sharpness_level = sharpness_val > 0 ? sharpness_val : 0;

--- a/Source/Lib/Codec/full_loop.c
+++ b/Source/Lib/Codec/full_loop.c
@@ -1130,6 +1130,7 @@ static void svt_av1_optimize_b(ModeDecisionContext *ctx, int16_t txb_skip_contex
                                uint8_t picture_qp, uint32_t lambda, int plane, PictureControlSet *pcs)
 
 {
+    FrameHeader        *frm_hdr = &pcs->ppcs->frm_hdr;
     int                    sharpness  = 0; // No Sharpness
     int                    fast_mode  = (ctx->rdoq_ctrls.eob_fast_y_inter && is_inter && !plane) ||
             (ctx->rdoq_ctrls.eob_fast_y_intra && !is_inter && !plane) ||
@@ -1168,7 +1169,10 @@ static void svt_av1_optimize_b(ModeDecisionContext *ctx, int16_t txb_skip_contex
             return;
     }
     int       rweight = 100;
-    const int rshift  = (pcs->scs->static_config.sharpness > 0 ? pcs->scs->static_config.sharpness : 1) + 1;
+    const int rshift = (frm_hdr->frame_type == KEY_FRAME && pcs->scs->static_config.tune == 3 && pcs->scs->static_config.sharpness <= 5)
+    ? (pcs->scs->static_config.sharpness > 0 ? pcs->scs->static_config.sharpness : 1) + 3
+    : (pcs->scs->static_config.sharpness > 0 ? pcs->scs->static_config.sharpness : 1) + 1;
+
     if (use_sharpness && delta_q_present && plane == 0) {
         int diff = ctx->sb_ptr->qindex - quantizer_to_qindex[picture_qp];
         if (diff < 0) {

--- a/Source/Lib/Codec/full_loop.c
+++ b/Source/Lib/Codec/full_loop.c
@@ -1169,6 +1169,8 @@ static void svt_av1_optimize_b(ModeDecisionContext *ctx, int16_t txb_skip_contex
             return;
     }
     int       rweight = 100;
+    // Boost rshift value +2 if a keyframe is present, if tune 3 is active, and if the sharpness below is <=5
+    // Otherwise, assume default behavior for rshift through user selected sharpness value
     const int rshift = (frm_hdr->frame_type == KEY_FRAME && pcs->scs->static_config.tune == 3 && pcs->scs->static_config.sharpness <= 5)
     ? (pcs->scs->static_config.sharpness > 0 ? pcs->scs->static_config.sharpness : 1) + 3
     : (pcs->scs->static_config.sharpness > 0 ? pcs->scs->static_config.sharpness : 1) + 1;

--- a/Source/Lib/Codec/full_loop.c
+++ b/Source/Lib/Codec/full_loop.c
@@ -1172,7 +1172,7 @@ static void svt_av1_optimize_b(ModeDecisionContext *ctx, int16_t txb_skip_contex
     // Boost rshift value +2 if a keyframe is present, if tune 3 is active, and if the sharpness below is <=5
     // Otherwise, assume default behavior for rshift through user selected sharpness value
     const int rshift = (frm_hdr->frame_type == KEY_FRAME && pcs->scs->static_config.tune == 3 && pcs->scs->static_config.sharpness <= 5)
-    ? (pcs->scs->static_config.sharpness > 0 ? pcs->scs->static_config.sharpness : 1) + 3
+    ? (pcs->scs->static_config.sharpness <= 1 ? 2 : (pcs->scs->static_config.sharpness > 0 ? pcs->scs->static_config.sharpness : 1) + 3)
     : (pcs->scs->static_config.sharpness > 0 ? pcs->scs->static_config.sharpness : 1) + 1;
 
     if (use_sharpness && delta_q_present && plane == 0) {


### PR DESCRIPTION
Currently, the code I added calculates these rshift values:

```
Sharpness value | KF | non-KF
0 | 4 | 2
1 | 4 | 2
2 | 5 | 3
3 | 6 | 4
4 | 7 | 5
5 | 8 | 6
6 | 7 | 7
7 | 8 | 8
```

This is not ideal since we want `--sharpness 0` to behave as normal and `--sharpness 1` to behave with only the sharpening features active.

Here are the rshift values calculated with this new PR:

```
Sharpness | KF | non-KF
0 | 2 | 2
1 | 2 | 2
2 | 5 | 3
3 | 6 | 4
4 | 7 | 5
5 | 8 | 6
6 | N/A | 7
7 | N/A | 8
```
