### PR TITLE
Prioritize clang and GCC in svt_av1_print_version

### DIFF
--- a/Source/Lib/Globals/enc_handle.c
+++ b/Source/Lib/Globals/enc_handle.c
@@ -6118,7 +6118,11 @@ EB_API void svt_av1_print_version(void) {
     SVT_INFO("-------------------------------------------\n");
     SVT_INFO("SVT [version]:\tSVT-AV1-PSY Encoder Lib %s\n", SVT_AV1_CVS_VERSION);
     const char *compiler =
-#if defined( _MSC_VER ) && (_MSC_VER >= 1930)
+#if defined(__clang__)
+    __VERSION__ "\t"
+#elif defined(__GNUC__)
+    "GCC " __VERSION__ "\t"
+#elif defined( _MSC_VER ) && (_MSC_VER >= 1930)
     "Visual Studio 2022"
 #elif defined( _MSC_VER ) && (_MSC_VER >= 1920)
     "Visual Studio 2019"
@@ -6128,10 +6132,6 @@ EB_API void svt_av1_print_version(void) {
     "Visual Studio 2015"
 #elif defined( _MSC_VER )
     "Visual Studio (old)"
-#elif defined(__clang__)
-    __VERSION__ "\t"
-#elif defined(__GNUC__)
-    "GCC " __VERSION__ "\t"
 #else
     "unknown compiler"
 #endif


### PR DESCRIPTION
When building on Windows ``_MSC_VER`` is always defined no matter what compiler is used, by swapping a few lines to prioritize clang or GCC, the actual compiler and version will be shown when using on of these compilers.

Realistically this should probably be changed or expanded because whatever Visual Studio version was used isn't very descriptive or helpful in any way, but this now would only happen when compiling with MSVC.